### PR TITLE
Add static mock API support for frontend

### DIFF
--- a/frontend/providers.json
+++ b/frontend/providers.json
@@ -1,0 +1,30 @@
+[
+  {
+    "provider_id": "prov_kumka",
+    "full_name": "Joseph Kumka",
+    "email": "joseph.kumka@gmail.com",
+    "phone": "6122297117",
+    "priority": 1,
+    "state_codes": ["MN", "WI"],
+    "offered_service_ids": [
+      "svc_general_consult",
+      "svc_mental_health",
+      "svc_follow_up"
+    ],
+    "active": true
+  },
+  {
+    "provider_id": "prov_lee",
+    "full_name": "Dr. Hannah Lee",
+    "email": "hannah.lee@example.com",
+    "phone": "6125550100",
+    "priority": 2,
+    "state_codes": ["MN", "ND"],
+    "offered_service_ids": [
+      "svc_general_consult",
+      "svc_dermatology",
+      "svc_follow_up"
+    ],
+    "active": true
+  }
+]

--- a/frontend/services.json
+++ b/frontend/services.json
@@ -1,0 +1,34 @@
+[
+  {
+    "service_id": "svc_general_consult",
+    "name": "General Consultation",
+    "price_cents": 7500,
+    "duration_min": 30,
+    "state_codes": ["MN", "WI", "ND", "SD"],
+    "active": true
+  },
+  {
+    "service_id": "svc_mental_health",
+    "name": "Mental Health Consultation",
+    "price_cents": 12000,
+    "duration_min": 60,
+    "state_codes": ["MN", "WI"],
+    "active": true
+  },
+  {
+    "service_id": "svc_dermatology",
+    "name": "Dermatology Consultation",
+    "price_cents": 9500,
+    "duration_min": 45,
+    "state_codes": ["MN"],
+    "active": true
+  },
+  {
+    "service_id": "svc_follow_up",
+    "name": "Follow-up Visit",
+    "price_cents": 5000,
+    "duration_min": 20,
+    "state_codes": ["MN", "WI", "ND"],
+    "active": true
+  }
+]


### PR DESCRIPTION
## Summary
- add static service and provider data files to unblock the UI when no backend is available
- extend the frontend to fall back to a local mock API that supports CRUD for services, providers, availability, appointments, and sales metrics
- persist mock data in localStorage and seed default availability so booking and admin workflows function during static hosting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf93208b88327be2c36f0b1373bb6